### PR TITLE
Update typescript linter in lint.lua

### DIFF
--- a/lua/plugins/lint.lua
+++ b/lua/plugins/lint.lua
@@ -8,7 +8,7 @@ return {
       sh = { "shellcheck" },
       terraform = { "terraform_validate", "tflint", "trivy" },
       tf = { "terraform_validate", "tflint", "trivy" },
-      typescript = { "prettierd" },
+      typescript = { "eslint_d" },
       yaml = { "yamllint" },
     },
     linters = {


### PR DESCRIPTION
Update typescript linter from `prettierd` to `eslint_d`.
prettier is a formatter not a linter.
nvm-lint doesn't support prettier/prettierd as a linter.